### PR TITLE
pow. Complex division by zero

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -241,6 +241,13 @@ class ComplexTest(unittest.TestCase):
         else:
             self.fail("should fail 0.0 to negative or complex power")
 
+        try:
+            0j ** (-1)
+        except ZeroDivisionError:
+            pass
+        else:
+            self.fail("should fail 0.0 to negative or complex power")
+
         # The following is used to exercise certain code paths
         self.assertEqual(a ** 105, a ** 105)
         self.assertEqual(a ** -105, a ** -105)

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -12,8 +12,8 @@ use crate::{
     types::{AsNumber, Comparable, Constructor, Hashable, PyComparisonOp, Representable},
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
-use num_complex::Complex64;
-use num_traits::Zero;
+use num_complex::{Complex64, ComplexFloat};
+use num_traits::{Zero, Signed};
 use rustpython_common::hash;
 use std::num::Wrapping;
 
@@ -103,7 +103,7 @@ fn inner_div(v1: Complex64, v2: Complex64, vm: &VirtualMachine) -> PyResult<Comp
 
 fn inner_pow(v1: Complex64, v2: Complex64, vm: &VirtualMachine) -> PyResult<Complex64> {
     if v1.is_zero() {
-        return if v2.im != 0.0 {
+        return if v2.im != 0.0 || (v1.im.is_zero() && v2.re().is_negative()) { 
             let msg = format!("{v1} cannot be raised to a negative or complex power");
             Err(vm.new_zero_division_error(msg))
         } else if v2.is_zero() {


### PR DESCRIPTION
Fixed case where pow for complex numbers doesn't result in division by zero. ([#5138](https://github.com/RustPython/RustPython/issues/5138))
pow(0j, -1) now results in a division by zero error.

Added unit test for this condition.