### PR TITLE
Deprecation warning fix

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -307,8 +307,6 @@ class ComplexTest(unittest.TestCase):
     def test_conjugate(self):
         self.assertClose(complex(5.3, 9.8).conjugate(), 5.3-9.8j)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_constructor(self):
         class NS:
             def __init__(self, value): self.value = value

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -507,9 +507,8 @@ impl Compiler {
             SymbolScope::Cell => {
                 cache = &mut info.cellvar_cache;
                 NameOpType::Deref
-            }
-            // // TODO: is this right?
-            // SymbolScope::Unknown => NameOpType::Global,
+            } // // TODO: is this right?
+              // SymbolScope::Unknown => NameOpType::Global,
         };
 
         if NameUsage::Load == usage && name == "__debug__" {

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -507,7 +507,7 @@ impl Compiler {
             SymbolScope::Cell => {
                 cache = &mut info.cellvar_cache;
                 NameOpType::Deref
-            } // // TODO: is this right?
+            } // TODO: is this right?
               // SymbolScope::Unknown => NameOpType::Global,
         };
 

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -75,7 +75,7 @@ impl PyObjectRef {
                     vm,
                 )?;
 
-                Ok(Some((ret.value, true)))
+                return Ok(Some((ret.value, true)));
             } else {
                 match result.payload::<PyComplex>() {
                     Some(complex_obj) => Ok(Some((complex_obj.value, true))),

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -75,7 +75,7 @@ impl PyObjectRef {
                     vm,
                 )?;
 
-                return Ok(Some((ret.value, true)))
+                return Ok(Some((ret.value, true)));
             } else {
                 return match result.payload::<PyComplex>() {
                     Some(complex_obj) => Ok(Some((complex_obj.value, true))),

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -77,7 +77,7 @@ impl PyObjectRef {
 
                 return Ok(Some((ret.value, true)));
             } else {
-                return match result.payload::<PyComplex>() {
+                match result.payload::<PyComplex>() {
                     Some(complex_obj) => Ok(Some((complex_obj.value, true))),
                     None => Err(vm.new_type_error(format!(
                         "__complex__ returned non-complex (type '{}')",

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -9,8 +9,9 @@ use crate::{
     },
     identifier,
     protocol::PyNumberMethods,
+    stdlib::warnings,
     types::{AsNumber, Comparable, Constructor, Hashable, PyComparisonOp, Representable},
-    AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine, stdlib::warnings,
+    AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use num_complex::Complex64;
 use num_traits::Zero;
@@ -59,7 +60,7 @@ impl PyObjectRef {
         }
         if let Some(method) = vm.get_method(self.clone(), identifier!(vm, __complex__)) {
             let result = method?.call((), vm)?;
-            
+
             let ret_class = result.class().to_owned();
             if let Some(ret) = result.downcast_ref::<PyComplex>() {
                 warnings::warn(
@@ -74,7 +75,7 @@ impl PyObjectRef {
                     vm,
                 )?;
 
-                return Ok(Some((ret.value, true)))
+                return Ok(Some((ret.value, true)));
             } else {
                 return match result.payload::<PyComplex>() {
                     Some(complex_obj) => Ok(Some((complex_obj.value, true))),
@@ -84,7 +85,6 @@ impl PyObjectRef {
                     ))),
                 };
             }
-            
         }
         // `complex` does not have a `__complex__` by default, so subclasses might not either,
         // use the actual stored value in this case

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -77,13 +77,13 @@ impl PyObjectRef {
 
                 return Ok(Some((ret.value, true)));
             } else {
-                match result.payload::<PyComplex>() {
+                return match result.payload::<PyComplex>() {
                     Some(complex_obj) => Ok(Some((complex_obj.value, true))),
                     None => Err(vm.new_type_error(format!(
                         "__complex__ returned non-complex (type '{}')",
                         result.class().name()
                     ))),
-                }
+                };
             }
         }
         // `complex` does not have a `__complex__` by default, so subclasses might not either,

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -10,7 +10,7 @@ use crate::{
     identifier,
     protocol::PyNumberMethods,
     types::{AsNumber, Comparable, Constructor, Hashable, PyComparisonOp, Representable},
-    AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
+    AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine, stdlib::warnings,
 };
 use num_complex::Complex64;
 use num_traits::Zero;
@@ -59,14 +59,32 @@ impl PyObjectRef {
         }
         if let Some(method) = vm.get_method(self.clone(), identifier!(vm, __complex__)) {
             let result = method?.call((), vm)?;
-            // TODO: returning strict subclasses of complex in __complex__ is deprecated
-            return match result.payload::<PyComplex>() {
-                Some(complex_obj) => Ok(Some((complex_obj.value, true))),
-                None => Err(vm.new_type_error(format!(
-                    "__complex__ returned non-complex (type '{}')",
-                    result.class().name()
-                ))),
-            };
+            
+            let ret_class = result.class().to_owned();
+            if let Some(ret) = result.downcast_ref::<PyComplex>() {
+                warnings::warn(
+                    vm.ctx.exceptions.deprecation_warning,
+                    format!(
+                        "__complex__ returned non-complex (type {}).  \
+                    The ability to return an instance of a strict subclass of complex \
+                    is deprecated, and may be removed in a future version of Python.",
+                        ret_class
+                    ),
+                    1,
+                    vm,
+                )?;
+
+                return Ok(Some((ret.value, true)))
+            } else {
+                return match result.payload::<PyComplex>() {
+                    Some(complex_obj) => Ok(Some((complex_obj.value, true))),
+                    None => Err(vm.new_type_error(format!(
+                        "__complex__ returned non-complex (type '{}')",
+                        result.class().name()
+                    ))),
+                };
+            }
+            
         }
         // `complex` does not have a `__complex__` by default, so subclasses might not either,
         // use the actual stored value in this case

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -75,7 +75,7 @@ impl PyObjectRef {
                     vm,
                 )?;
 
-                return Ok(Some((ret.value, true)));
+                Ok(Some((ret.value, true)))
             } else {
                 return match result.payload::<PyComplex>() {
                     Some(complex_obj) => Ok(Some((complex_obj.value, true))),

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -75,9 +75,9 @@ impl PyObjectRef {
                     vm,
                 )?;
 
-                Ok(Some((ret.value, true)))
+                return Ok(Some((ret.value, true)))
             } else {
-                match result.payload::<PyComplex>() {
+                return match result.payload::<PyComplex>() {
                     Some(complex_obj) => Ok(Some((complex_obj.value, true))),
                     None => Err(vm.new_type_error(format!(
                         "__complex__ returned non-complex (type '{}')",

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -77,13 +77,13 @@ impl PyObjectRef {
 
                 Ok(Some((ret.value, true)))
             } else {
-                return match result.payload::<PyComplex>() {
+                match result.payload::<PyComplex>() {
                     Some(complex_obj) => Ok(Some((complex_obj.value, true))),
                     None => Err(vm.new_type_error(format!(
                         "__complex__ returned non-complex (type '{}')",
                         result.class().name()
                     ))),
-                };
+                }
             }
         }
         // `complex` does not have a `__complex__` by default, so subclasses might not either,

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -75,9 +75,9 @@ impl PyObjectRef {
                     vm,
                 )?;
 
-                return Ok(Some((ret.value, true)))
+                Ok(Some((ret.value, true)))
             } else {
-                return match result.payload::<PyComplex>() {
+                match result.payload::<PyComplex>() {
                     Some(complex_obj) => Ok(Some((complex_obj.value, true))),
                     None => Err(vm.new_type_error(format!(
                         "__complex__ returned non-complex (type '{}')",


### PR DESCRIPTION
Fixed case where returning strict subclasses of complex in __complex__ doesn't  give a deprecation warning.